### PR TITLE
Handle custom table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ INSTALLED_APPS = [
 
 # Usage
 
+For full detailed instructions see https://odwyer.software/blog/how-to-rename-an-existing-django-application
 
 `python manage.py rename_app <old_app_name> <new_app_name>`
 
-For full detailed instructions see https://odwyer.software/blog/how-to-rename-an-existing-django-application
+If some of the affected models of your app use a custom table name by setting the attribute [db_table](https://docs.djangoproject.com/en/4.0/ref/models/options/#db-table), use the following additional argument:
+
+`python manage.py rename_app <old_app_name> <new_app_name> -m "<old_tab_1>=<new_tab_1>" "<old_tab_2>=<new_tab_2>"`
 

--- a/django_rename_app/management/commands/rename_app.py
+++ b/django_rename_app/management/commands/rename_app.py
@@ -1,72 +1,90 @@
 """
 A Django Management Command to rename existing Django Applications.
-
 See https://github.com/odwyersoftware/django-rename-app
 """
 
 import logging
+from typing import Dict, List, Optional
 
-from django.core.management.base import BaseCommand
-from django.db import connection, ProgrammingError
-from django.db.backends.utils import truncate_name
 from django.apps import apps
+from django.core.management.base import BaseCommand
+from django.db import ProgrammingError, connection
+from django.db.backends.utils import truncate_name
 
 logger = logging.getLogger(__name__)
 
 
+def parse_new_tab_name_mapper(args: Optional[List[str]]) -> Dict[str, str]:
+    """
+    Parse --map-new-tab-name argument.
+
+    Args:
+        args (Optional[List[str]]): arguments to parse, something like: ['<old_tab_1>=<new_tab_1>','<old_tab_2>=<new_tab_2>']
+
+    Returns:
+        Dict[str, str]: Return a dict mapping new tab names to old tab names, something like:
+        {<old_tab_1>: <new_tab_1>, <old_tab_2>: <new_tab_2>}
+    """
+
+    if not args:
+        return {}
+    res = {}
+    for a in args:
+        old_tab_name, new_tab_name = a.split('=')
+        res[new_tab_name] = old_tab_name
+    return res
+
+
 class Command(BaseCommand):
-    help = (
-        'Renames a Django Application. Usage rename_app [old_app_name] [new_app_name]'
-    )
+    help = 'Renames a Django Application. Usage rename_app [old_app_name] [new_app_name]'
 
     def add_arguments(self, parser):
         parser.add_argument('old_app_name', nargs=1, type=str)
         parser.add_argument('new_app_name', nargs=1, type=str)
+        parser.add_argument(
+            '-m',
+            '--map-new-tab-name',
+            nargs='*',
+            type=str,
+            help='Map new db_tables to the old db_tables.'
+            'Required only for models with custom db_table attribute.'
+            'Example: --map-new-tab-name <old_tab_1>=<name_tab_1> <old_tab_2>=<new_tab_2> ...',
+        )
 
-    def handle(self, old_app_name, new_app_name, *args, **options):
+    def handle(self, old_app_name: str, new_app_name: str, *args, **options):  # type: ignore
         with connection.cursor() as cursor:
             old_app_name = old_app_name[0]
             new_app_name = new_app_name[0]
+            table_names_mapper: Dict[str, str] = parse_new_tab_name_mapper(options.get('map_new_tab_name'))
 
-            cursor.execute(
-                "SELECT * FROM django_content_type "
-                f"where app_label='{new_app_name}'"
-            )
+            cursor.execute("SELECT * FROM django_content_type " f"where app_label='{new_app_name}'")
             has_already_been_ran = cursor.fetchone()
             if has_already_been_ran:
-                logger.info(
-                    'Rename has already been done, exiting without '
-                    'making any changes'
-                )
+                logger.info('Rename has already been done, exiting without ' 'making any changes')
                 return None
 
             cursor.execute(
-                f"UPDATE django_content_type SET app_label='{new_app_name}' "
-                f"WHERE app_label='{old_app_name}'"
+                f"UPDATE django_content_type SET app_label='{new_app_name}' " f"WHERE app_label='{old_app_name}'"
             )
-            cursor.execute(
-                f"UPDATE django_migrations SET app='{new_app_name}' "
-                f"WHERE app='{old_app_name}'"
-            )
+            cursor.execute(f"UPDATE django_migrations SET app='{new_app_name}' " f"WHERE app='{old_app_name}'")
+
             models = apps.all_models[new_app_name]
             models.update(apps.all_models[old_app_name])
-            for model_name in models:
-                old_table_name = truncate_name(
-                    f"{old_app_name}_{model_name}",
-                    connection.ops.max_name_length()
-                )
-                new_table_name = truncate_name(
-                    f"{new_app_name}_{model_name}",
-                    connection.ops.max_name_length()
-                )
+            for model_name, model in models.items():
+                old_table_name = truncate_name(f"{old_app_name}_{model_name}", connection.ops.max_name_length())  # type: ignore
+                new_table_name = truncate_name(f"{new_app_name}_{model_name}", connection.ops.max_name_length())  # type: ignore
 
-                query = (
-                    f"ALTER TABLE {old_table_name} "
-                    f"RENAME TO {new_table_name}"
-                )
+                # Use a custom mapping for the current model table if set (required only for models with db_table set)
+                if (
+                    getattr(model, '_meta', None)
+                    and getattr(model._meta, 'db_table', None)
+                    and model._meta.db_table in table_names_mapper
+                ):
+                    old_table_name = table_names_mapper[model._meta.db_table]
+                    new_table_name = model._meta.db_table
+
+                query = f"ALTER TABLE {old_table_name} " f"RENAME TO {new_table_name}"
                 try:
                     cursor.execute(query)
                 except ProgrammingError:
-                    logger.warning(
-                        'Rename query failed: "%s"', query, exc_info=True
-                    )
+                    logger.warning('Rename query failed: "%s"', query, exc_info=True)


### PR DESCRIPTION
if some models within old_app have a custom db_table attribute the last step related to ALTER TABLE commands fails because the tables names are built from model name following the standard name assigned by django.

This update add the support of -m or --map-new-tab-name option which can be used to set mapping from old table names to new ones only for those with a custom name. Something like:

`python manage.py rename_app <old_app_name> <new_app_name> -m "<old_tab_1>=<new_tab_1>" "<old_tab_2>=<new_tab_2>"`