### PR TITLE
Remove lines that seem to have no effect

### DIFF
--- a/django_rename_app/management/commands/rename_app.py
+++ b/django_rename_app/management/commands/rename_app.py
@@ -53,9 +53,6 @@ class Command(BaseCommand):
                 f"WHERE app='{old_app_name}'"
             )
 
-            models = apps.all_models[new_app_name]
-            models.update(apps.all_models[old_app_name])
-
             cursor.execute(
                 f"SELECT * FROM  django_content_type "
                 f"WHERE app_label='{new_app_name}'"


### PR DESCRIPTION
We're storing the list of model names in a dict, but it's not being used anywhere. Hence removing those two lines.